### PR TITLE
Build: Add CentOS 7 build strategy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy	
 
   steps:
-  - script: sudo apt-get install -y mesa-common-dev libegl1-mesa-dev mesa-utils mesa-utils-extra 
+  - script: sudo apt-get install -y mesa-common-dev libegl1-mesa-dev mesa-utils mesa-utils-extra nasm
   - template: .ci/use-node.yml	
   - template: .ci/restore-build-cache.yml	
   - template: .ci/esy-build-steps.yml	

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,3 +87,23 @@ jobs:
 #       esy  
 #     displayName: 'esy (with modified esy-bash)'
    
+- job: CentOS
+  displayName: 'Linux - CentOS - Docker Image'
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  variables:
+    STAGING_DIRECTORY: $(Build.StagingDirectory)
+    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+    # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
+
+  steps:
+  - script: docker build -t centos esy/docker/centos
+    displayName: 'docker build'
+  - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'which ragel'
+  - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'cd esy-skia && ls -a'
+  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
+  - template: .ci/publish-linux.yml
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,5 +104,5 @@ jobs:
     displayName: 'docker build'
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'which ragel'
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'cd esy-skia && ls -a'
-  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
+  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd esy-skia && ./esy/docker-build.sh'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,5 +105,4 @@ jobs:
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'which ragel'
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'cd esy-skia && ls -a'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd oni2 && ./scripts/docker-build.sh'
-  - template: .ci/publish-linux.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,5 +104,5 @@ jobs:
     displayName: 'docker build'
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'which ragel'
   - script: docker run --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'cd esy-skia && ls -a'
-  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/oni2,type=bind centos /bin/bash -c 'cd esy-skia && ./esy/docker-build.sh'
+  - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/esy-skia,type=bind centos /bin/bash -c 'cd esy-skia && ./esy/docker-build.sh'
 

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "765ea932e218efddce6c936e8080efd5",
+  "checksum": "d1dd34a93c0cb976bd9a3203c4dad740",
   "root": "esy-skia@link-dev:./package.json",
   "node": {
     "esy-skia@link-dev:./package.json": {
@@ -13,39 +13,34 @@
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:prometheansacrifice/libjpeg-turbo#50e8e32c48@d41d8cd9",
+        "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "esy-nasm@github:prometheansacrifice/esy-nasm#6240bdbb164476558d3738812fbbe48f66cc904a@d41d8cd9": {
-      "id":
-        "esy-nasm@github:prometheansacrifice/esy-nasm#6240bdbb164476558d3738812fbbe48f66cc904a@d41d8cd9",
+    "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9": {
+      "id": "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
       "name": "esy-nasm",
-      "version":
-        "github:prometheansacrifice/esy-nasm#6240bdbb164476558d3738812fbbe48f66cc904a",
+      "version": "github:revery-ui/esy-nasm#64a802b",
       "source": {
         "type": "install",
-        "source": [
-          "github:prometheansacrifice/esy-nasm#6240bdbb164476558d3738812fbbe48f66cc904a"
-        ]
+        "source": [ "github:revery-ui/esy-nasm#64a802b" ]
       },
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:prometheansacrifice/libjpeg-turbo#50e8e32c48@d41d8cd9": {
-      "id":
-        "esy-libjpeg-turbo@github:prometheansacrifice/libjpeg-turbo#50e8e32c48@d41d8cd9",
+    "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9": {
+      "id": "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:prometheansacrifice/libjpeg-turbo#50e8e32c48",
+      "version": "github:bryphe/libjpeg-turbo#12d3cef",
       "source": {
         "type": "install",
-        "source": [ "github:prometheansacrifice/libjpeg-turbo#50e8e32c48" ]
+        "source": [ "github:bryphe/libjpeg-turbo#12d3cef" ]
       },
       "overrides": [],
       "dependencies": [
-        "esy-nasm@github:prometheansacrifice/esy-nasm#6240bdbb164476558d3738812fbbe48f66cc904a@d41d8cd9",
+        "esy-nasm@github:revery-ui/esy-nasm#64a802b@d41d8cd9",
         "esy-cmake@github:prometheansacrifice/esy-cmake#2a47392def755074afbf63eb794b94135476b1d1@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d1dd34a93c0cb976bd9a3203c4dad740",
+  "checksum": "bb9534865768b15a531aa28e4772d0c3",
   "root": "esy-skia@link-dev:./package.json",
   "node": {
     "esy-skia@link-dev:./package.json": {
@@ -13,7 +13,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -30,13 +30,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9": {
-      "id": "esy-libjpeg-turbo@github:bryphe/libjpeg-turbo#12d3cef@d41d8cd9",
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9": {
+      "id":
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:bryphe/libjpeg-turbo#12d3cef",
+      "version": "github:revery-ui/libjpeg-turbo#a494a2c",
       "source": {
         "type": "install",
-        "source": [ "github:bryphe/libjpeg-turbo#12d3cef" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#a494a2c" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -27,7 +27,7 @@ then
 else
 
     if ! [ -x "$(command -v clang++)" ]; then
-        echo "Manully activating llvm toolset 7.0..."
+        echo "Manually activating llvm toolset 7.0..."
         source /opt/rh/llvm-toolset-7.0/enable
         echo "-- clang version:"
         clang -v

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -32,7 +32,7 @@ else
         source /opt/rh/llvm-toolset-7.0/enable
         echo "-- clang version:"
         clang -v
-        echo "-- clang++ version:""
+        echo "-- clang++ version:"
         clang++ -v
     else
         echo "llvm toolset-7.0 does not need to be manually activated"

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -25,6 +25,19 @@ then
     esy/gendef.exe - $cur__target_dir/out/Shared/skia.dll > $cur__target_dir/out/Shared/skia.def
     x86_64-W64-mingw32-dlltool.exe -D $cur__target_dir/out/Shared/skia.dll -d $cur__target_dir/out/Shared/skia.def -A -l $cur__target_dir/out/Shared/libskia.a
 else
+
+    if [[ -x "/opt/rh/llvm-toolset-7.0/enable" ]]
+    then
+        echo "Manully activating llvm toolset 7.0..."
+        source /opt/rh/llvm-toolset-7.0/enable
+        echo "-- clang version:"
+        clang -v
+        echo "-- clang++ version:""
+        clang++ -v
+    else
+        echo "llvm toolset-7.0 does not need to be manually activated"
+    fi
+
     bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"clang\" cxx=\"clang++\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
     ninja.exe -C $cur__target_dir/out/Static
 fi

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -26,8 +26,7 @@ then
     x86_64-W64-mingw32-dlltool.exe -D $cur__target_dir/out/Shared/skia.dll -d $cur__target_dir/out/Shared/skia.def -A -l $cur__target_dir/out/Shared/libskia.a
 else
 
-    if [[ -x "/opt/rh/llvm-toolset-7.0/enable" ]]
-    then
+    if ! [ -x "$(command -v clang++)" ]; then
         echo "Manully activating llvm toolset 7.0..."
         source /opt/rh/llvm-toolset-7.0/enable
         echo "-- clang version:"

--- a/esy/docker-build.sh
+++ b/esy/docker-build.sh
@@ -2,8 +2,4 @@ source /opt/rh/llvm-toolset-7.0/enable
 clang -v
 
 esy install
-esy bootstrap
-node install-node-deps.js --production
 esy build
-esy x Oni2 -f --checkhealth
-esy create-release

--- a/esy/docker-build.sh
+++ b/esy/docker-build.sh
@@ -1,5 +1,6 @@
 source /opt/rh/llvm-toolset-7.0/enable
 clang -v
+clang++ -v
 
 esy install
 esy build

--- a/esy/docker-build.sh
+++ b/esy/docker-build.sh
@@ -1,0 +1,9 @@
+source /opt/rh/llvm-toolset-7.0/enable
+clang -v
+
+esy install
+esy bootstrap
+node install-node-deps.js --production
+esy build
+esy x Oni2 -f --checkhealth
+esy create-release

--- a/esy/docker/centos/Dockerfile
+++ b/esy/docker/centos/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install gcc-c++ make sudo
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
 RUN yum -y install nodejs npm coreutils grep tar sed gawk diffutils autoconf
 
-RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git
+RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git nasm
 
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/colm-0.13.0.4-2.el7.x86_64.rpm
 RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/r/ragel-7.0.0.9-2.el7.x86_64.rpm

--- a/esy/docker/centos/Dockerfile
+++ b/esy/docker/centos/Dockerfile
@@ -1,0 +1,29 @@
+FROM centos:7
+
+RUN yum -y update
+
+RUN yum -y install centos-release-scl
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum -y install llvm-toolset-7.0
+RUN scl enable llvm-toolset-7.0 'clang -v'
+
+RUN yum -y install gcc-c++ make sudo
+RUN curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
+RUN yum -y install nodejs npm coreutils grep tar sed gawk diffutils autoconf
+
+RUN yum -y install file fuse fuse-devel wget bzip2-devel libXt-devel libSM-devel libICE-devel ncurses-devel libacl-devel libxrandr-devel libXinerama-devel libXcursor-devel libXi-devel mesa-libGL-devel mesa-libGLU-devel gtk3-devel perl-Digest-SHA bzip2 m4 patch which cmake3 git
+
+RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/colm-0.13.0.4-2.el7.x86_64.rpm
+RUN rpm -i https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/r/ragel-7.0.0.9-2.el7.x86_64.rpm
+
+RUN node -v
+RUN npm -v
+
+RUN npm install --global --unsafe-perm=true esy@0.5.8
+
+RUN yum -y install epel-release
+RUN yum -y remove git
+RUN rpm -U https://centos7.iuscommunity.org/ius-release.rpm
+RUN yum -y install git2u
+
+RUN yum -y install nasm

--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
   },
   "dependencies": {
     "@esy-cross/ninja-build": "^1.8.2001",
-    "esy-libjpeg-turbo": "bryphe/libjpeg-turbo#12d3cef"
-  },
-  "resolutions": {
-    "esy-nasm": "github:revery-ui/esy-nasm#64a802b"
+    "esy-libjpeg-turbo": "revery-ui/libjpeg-turbo#a494a2c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   "dependencies": {
     "@esy-cross/ninja-build": "^1.8.2001",
     "esy-libjpeg-turbo": "bryphe/libjpeg-turbo#12d3cef"
+  },
+  "resolutions": {
+    "esy-nasm": "github:revery-ui/esy-nasm#64a802b"
   }
 }


### PR DESCRIPTION
A blocker from including this library in the build for Onivim 2 / Revery is that we require shipping on CentOS 7, but currently, the esy dependencies don't build there.

This adds a CI strategy to validate the CentOS build. There is no CentOS 7 build image, so we use docker.