### PR TITLE
Build: Get building on CentOS 7 w/ correct gcc toolchain

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "bb9534865768b15a531aa28e4772d0c3",
+  "checksum": "d5344e23b07102fb85cae81d39e097b4",
   "root": "esy-skia@link-dev:./package.json",
   "node": {
     "esy-skia@link-dev:./package.json": {
@@ -13,7 +13,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
         "@esy-cross/ninja-build@1.8.2001@d41d8cd9"
       ],
       "devDependencies": []
@@ -30,14 +30,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9": {
+    "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9": {
       "id":
-        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#a494a2c@d41d8cd9",
+        "esy-libjpeg-turbo@github:revery-ui/libjpeg-turbo#61e031f@d41d8cd9",
       "name": "esy-libjpeg-turbo",
-      "version": "github:revery-ui/libjpeg-turbo#a494a2c",
+      "version": "github:revery-ui/libjpeg-turbo#61e031f",
       "source": {
         "type": "install",
-        "source": [ "github:revery-ui/libjpeg-turbo#a494a2c" ]
+        "source": [ "github:revery-ui/libjpeg-turbo#61e031f" ]
       },
       "overrides": [],
       "dependencies": [

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -26,17 +26,21 @@ then
     x86_64-W64-mingw32-dlltool.exe -D $cur__target_dir/out/Shared/skia.dll -d $cur__target_dir/out/Shared/skia.def -A -l $cur__target_dir/out/Shared/libskia.a
 else
 
+    CC=clang
+    CXX=clang++
     if ! [ -x "$(command -v clang++)" ]; then
         echo "Manually activating llvm toolset 7.0..."
         source /opt/rh/llvm-toolset-7.0/enable
+        CC="clang --gcc-toolchain=/usr/lib/gcc/x86_64-redhat-linux/4.8.5 -stdlib=libstdc++"
+        CXX="clang++ --gcc-toolchain=/usr/lib/gcc/x86_64-redhat-linux/4.8.5 -I/usr/include/c++/4.8.5 -I/usr/include/c++/4.8.5/x86_64-redhat-linux -std=c++11 -stdlib=libstdc++"
         echo "-- clang version:"
-        clang -v
+        $CC -v
         echo "-- clang++ version:"
-        clang++ -v
+	$CXX -v
     else
         echo "llvm toolset-7.0 does not need to be manually activated"
     fi
 
-    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"clang\" cxx=\"clang++\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
+    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"$CC\" cxx=\"$CXX\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
     ninja.exe -C $cur__target_dir/out/Static
 fi

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "@esy-cross/ninja-build": "^1.8.2001",
-    "esy-libjpeg-turbo": "revery-ui/libjpeg-turbo#a494a2c"
+    "esy-libjpeg-turbo": "revery-ui/libjpeg-turbo#61e031f"
   }
 }


### PR DESCRIPTION
__Issue:__ `reason-skia` would fail to link properly on CentOS 7 when built with the OCaml toolchain. There were mismatches in the symbols for thread libraries.

__Defect:__ `clang`, by default, was pulling in a newer version of the `gcc` compiler + libraries. This was mismatched with `gcc` 4.8.5, which we were building with in the ocaml space.

__Fix:__ Match up gcc versions for clang by specifying the `-gcc-toolchain` option.