### PR TITLE
Bugfix: build with clang 10

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -365,10 +365,6 @@ config("warnings") {
       "-Wno-deprecated-declarations",
       "-Wno-maybe-uninitialized",
       "-Wno-extra-semi-stmt",
-
-      # clang 10 fixes
-      "-Wno-anon-enum-enum-conversion",
-      "-Wno-sizeof-array-div",
     ]
     cflags_cc += [
       "-Wnon-virtual-dtor",
@@ -380,6 +376,10 @@ config("warnings") {
     cflags += [
       "-Weverything",
       "-Wno-unknown-warning-option",  # Let older Clangs ignore newer Clangs' warnings.
+
+      # clang 10 fixes
+      "-Wno-anon-enum-enum-conversion",
+      "-Wno-sizeof-array-div",
     ]
 
     if (target_cpu == "arm" && is_ios) {

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -365,6 +365,10 @@ config("warnings") {
       "-Wno-deprecated-declarations",
       "-Wno-maybe-uninitialized",
       "-Wno-extra-semi-stmt",
+
+      # clang 10 fixes
+      "-Wno-anon-enum-enum-conversion",
+      "-Wno-sizeof-array-div",
     ]
     cflags_cc += [
       "-Wnon-virtual-dtor",


### PR DESCRIPTION
Clang 10 seems to have introduced a couple new warnings that caused the build to fail. This disables those warnings.