### PR TITLE
fix(macOS): build with new XCode12 cross-compilation

### DIFF
--- a/esy/build.sh
+++ b/esy/build.sh
@@ -41,6 +41,6 @@ else
         echo "llvm toolset-7.0 does not need to be manually activated"
     fi
 
-    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"$CC\" cxx=\"$CXX\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
+    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"$CC\" cxx=\"$CXX\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\", \"-Wno-poison-system-directories\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
     ninja.exe -C $cur__target_dir/out/Static
 fi


### PR DESCRIPTION
This is to address onivim/oni2#2550, onivim/oni2#2508, and probably some others that I missed.

This doesn't really get to the "root" of the issue, just ignores the compiler warning for now. It should be safe since we aren't _actually_ cross compiling, but if/when we begin to, we'll need to remove the ignore flag and try to fix the underlying issue.