### PR TITLE
fix: disable warnings to unbreak build with clang 10.2

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -380,6 +380,12 @@ config("warnings") {
       # clang 10 fixes
       "-Wno-anon-enum-enum-conversion",
       "-Wno-sizeof-array-div",
+
+      # clang 10.2 fixes
+      "-Wno-psabi",
+      "-Wno-suggest-destructor-override",
+      "-Wno-suggest-override",
+      "-Wno-uninitialized-const-reference",
     ]
 
     if (target_cpu == "arm" && is_ios) {


### PR DESCRIPTION
Disables a few more warnings in order to unbreak building with clang 10.2 on Arch Linux.