### PR TITLE
feat: enable experimental SVG support in builds

### DIFF
--- a/esy/build.sh
+++ b/esy/build.sh
@@ -41,6 +41,9 @@ else
         echo "llvm toolset-7.0 does not need to be manually activated"
     fi
 
-    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"$CC\" cxx=\"$CXX\" skia_use_system_libjpeg_turbo=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\", \"-Wno-poison-system-directories\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
-    ninja.exe -C $cur__target_dir/out/Static
+    bin/gn gen $cur__target_dir/out/Static --script-executable="$PYTHON_BINARY" "--args=cc=\"$CC\" cxx=\"$CXX\" skia_use_system_libjpeg_turbo=true skia_enable_tools=true is_debug=false extra_cflags=[\"-I${ESY_LIBJPEG_TURBO_PREFIX}/include\"] extra_ldflags=[\"-L${ESY_LIBJPEG_TURBO_PREFIX}/lib\", \"-ljpeg\" ]" || exit -1
+    ninja.exe -C $cur__target_dir/out/Static skia skia.h experimental_svg_model || exit -1
+    
+    # Add the SVG object files to the Skia archive
+    ar r $cur__target_dir/out/Static/libskia.a $cur__target_dir/out/Static/obj/experimental/svg/model/*.o
 fi

--- a/esy/install.sh
+++ b/esy/install.sh
@@ -5,6 +5,10 @@ OS=$1
 # Copy artifacts into output directories
 mkdir -p $cur__install/include
 cp -a $cur__root/include/. $cur__install/include/
+
+mkdir -p $cur__install/include/svg/model
+cp $cur__root/experimental/svg/model/*.h $cur__install/include/svg/model/
+
 if [[ $OS == 'windows' ]]
 then
     cp $cur__target_dir/out/Shared/libskia.a $cur__lib

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -386,6 +386,9 @@ config("warnings") {
       "-Wno-suggest-destructor-override",
       "-Wno-suggest-override",
       "-Wno-uninitialized-const-reference",
+
+      # macOS cross-compilation fix
+      "-Wno-poison-system-directories",
     ]
 
     if (target_cpu == "arm" && is_ios) {


### PR DESCRIPTION
This enables experimental SVG support by:
- enabling `skia_enable_tools` in gn
- adding the `experimental_svg_model` build target
- adding the SVG object files to the `libskia.a` archive file
- copying the SVG include files to the esy include directory