### PR TITLE
fix(SVG): add ref/unref functions to header

### DIFF
--- a/include/c/sk_svg.h
+++ b/include/c/sk_svg.h
@@ -23,6 +23,8 @@ SK_C_API void sk_svgdom_set_container_size(sk_svgdom_t *svgdom, float width, flo
 SK_C_API float sk_svgdom_get_container_width(sk_svgdom_t *svgdom);
 SK_C_API float sk_svgdom_get_container_height(sk_svgdom_t *svgdom);
 SK_C_API sk_svgdom_t *sk_svgdom_create_from_stream(sk_stream_t *stream);
+SK_C_API void sk_svgdom_ref(const sk_svgdom_t *svg);
+SK_C_API void sk_svgdom_unref(const sk_svgdom_t *svg);
 #endif
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/patches/svg-c-bindings.patch
+++ b/patches/svg-c-bindings.patch
@@ -1,8 +1,8 @@
 diff --git a/include/c/sk_svg.h b/include/c/sk_svg.h
-index f0e384423e..5e0ccc519f 100644
+index f0e384423e..23a374877e 100644
 --- a/include/c/sk_svg.h
 +++ b/include/c/sk_svg.h
-@@ -16,6 +16,15 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
+@@ -16,6 +16,17 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
  
  SK_C_API sk_canvas_t* sk_svgcanvas_create(const sk_rect_t* bounds, sk_xmlwriter_t* writer);
  
@@ -13,6 +13,8 @@ index f0e384423e..5e0ccc519f 100644
 +SK_C_API float sk_svgdom_get_container_width(sk_svgdom_t *svgdom);
 +SK_C_API float sk_svgdom_get_container_height(sk_svgdom_t *svgdom);
 +SK_C_API sk_svgdom_t *sk_svgdom_create_from_stream(sk_stream_t *stream);
++SK_C_API void sk_svgdom_ref(const sk_svgdom_t *svg);
++SK_C_API void sk_svgdom_unref(const sk_svgdom_t *svg);
 +#endif
 +
  SK_C_PLUS_PLUS_END_GUARD


### PR DESCRIPTION
I accidentally forgot this in #32. Oops!