### PR TITLE
fix: disable four-char-constants warning for clang 13

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -387,6 +387,9 @@ config("warnings") {
       "-Wno-suggest-override",
       "-Wno-uninitialized-const-reference",
 
+      # clang 12? fixes
+      "-Wno-four-char-constants",
+
       # macOS cross-compilation fix
       "-Wno-poison-system-directories",
     ]


### PR DESCRIPTION
Addresses https://github.com/revery-ui/revery/issues/1091 and https://github.com/revery-ui/revery-quick-start/issues/96